### PR TITLE
implement clean subcommand, fixes #9

### DIFF
--- a/command/clean/command.go
+++ b/command/clean/command.go
@@ -21,7 +21,7 @@ func NewCommand(name string) *CleanCommand {
 
 // Run performs action of clean command
 func (c *CleanCommand) Run(parser *dockerfile.Parser, args []string) error {
-	if _, ok := os.Stat(config.Vendordir); nil == ok {
+	if _, err := os.Stat(config.Vendordir); nil == err {
 		return os.RemoveAll(config.Vendordir)
 	}
 

--- a/command/clean/command.go
+++ b/command/clean/command.go
@@ -1,0 +1,29 @@
+package clean
+
+import (
+	"flag"
+	"github.com/tueftler/doget/command"
+	"github.com/tueftler/doget/config"
+	"github.com/tueftler/doget/dockerfile"
+	"os"
+)
+
+// CleanCommand allows to remove the vendor directory and all of its contents
+type CleanCommand struct {
+	command.Command
+	flags *flag.FlagSet
+}
+
+// NewCommand creates new clean command instance
+func NewCommand(name string) *CleanCommand {
+	return &CleanCommand{flags: flag.NewFlagSet(name, flag.ExitOnError)}
+}
+
+// Run performs action of clean command
+func (c *CleanCommand) Run(parser *dockerfile.Parser, args []string) error {
+	if _, ok := os.Stat(config.Vendordir); nil == ok {
+		return os.RemoveAll(config.Vendordir)
+	}
+
+	return nil
+}

--- a/command/transform/command.go
+++ b/command/transform/command.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/tueftler/doget/command"
+	"github.com/tueftler/doget/command/clean"
 	"github.com/tueftler/doget/dockerfile"
 	"io"
 	"os"
@@ -31,12 +32,18 @@ func open(output string) (io.Writer, error) {
 // Runs transform command
 func (c *TransformCommand) Run(parser *dockerfile.Parser, args []string) error {
 	var input, output string
+	var performClean bool
 
 	c.flags.StringVar(&input, "in", "Dockerfile.in", "Input. Use - for standard input")
 	c.flags.StringVar(&output, "out", "Dockerfile", "Output. Use - for standard output")
+	c.flags.BoolVar(&performClean, "clean", false, "Remove vendor directory after transformation")
 	c.flags.Parse(args)
 
 	fmt.Fprintf(os.Stderr, "> Running transform(%q -> %q)\n", input, output)
+
+	if performClean {
+		defer clean.NewCommand("clean").Run(parser, args)
+	}
 
 	// Open output
 	out, err := open(output)

--- a/command/transform/download.go
+++ b/command/transform/download.go
@@ -2,6 +2,7 @@ package transform
 
 import (
 	"fmt"
+	"github.com/tueftler/doget/config"
 	"github.com/tueftler/doget/use"
 	"io"
 	"net/http"
@@ -74,7 +75,7 @@ func download(uri, file string, progress func(transferred, total int64)) (int64,
 }
 
 func fetch(origin *use.Origin, progress func(transferred, total int64)) (string, error) {
-	target := filepath.Join("vendor", origin.Host, origin.Vendor, origin.Name)
+	target := filepath.Join(config.Vendordir, origin.Host, origin.Vendor, origin.Name)
 	zip := filepath.Join(target, origin.Version+".zip")
 
 	if err := os.MkdirAll(target, 0755); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,9 @@ type Configuration struct {
 	Repositories map[string]map[string]string `yaml:"repositories"`
 }
 
+// Vendordir depicts the basename of the directory where downloaded traits are stored
+const Vendordir string = "doget_modules"
+
 var (
 	search = []func() string{
 		func() string { return ".doget.yml" },

--- a/doget.go
+++ b/doget.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/tueftler/doget/command"
+	"github.com/tueftler/doget/command/clean"
 	"github.com/tueftler/doget/command/dump"
 	"github.com/tueftler/doget/command/transform"
 	"github.com/tueftler/doget/config"
@@ -16,6 +17,7 @@ var (
 	commands = map[string]command.Command{
 		"dump":      dump.NewCommand("dump"),
 		"transform": transform.NewCommand("transform"),
+		"clean":     clean.NewCommand("clean"),
 	}
 )
 
@@ -29,7 +31,7 @@ func configuration(file string) (*config.Configuration, error) {
 
 func main() {
 	var (
-		cmdName    = flag.String("#1", "", "Command, one of [dump, transform]")
+		cmdName    = flag.String("#1", "", "Command, one of [clean, dump, transform]")
 		configFile = flag.String("config", "", "Configuration file to use")
 	)
 	flag.Parse()


### PR DESCRIPTION
This introduces a new subcommand to clean up and remove the vendor directory as defined in #9. Also, it renames the used vendor directory to `doget_modules` as previously discussed.

Additionally, a switch `-clean` for the transform subcommand is introduced which allows to remove the vendor directory immediately after the transformation is done, leaving no traces that the command has run except the newly created Dockerfile.