### PR TITLE
do not end line prematurely on escaped character, fixes #15

### DIFF
--- a/dockerfile/dockerfile_test.go
+++ b/dockerfile/dockerfile_test.go
@@ -58,6 +58,12 @@ CMD /bin/bash
 	assertParsed(4, func(d Dockerfile) field { return len(d.Statements) }, file, t)
 }
 
+func Test_parsingIssue15(t *testing.T) {
+	file := `RUN sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 'http://elasticsearch:9200'!" /opt/kibana/config/kibana.yml`
+
+	assertParsed(`sed -ri "s!^(\#\s*)?(elasticsearch\.url:).*!\2 'http://elasticsearch:9200'!" /opt/kibana/config/kibana.yml`, func(d Dockerfile) field { return d.Statements[0].(*Run).Command }, file, t)
+}
+
 func Test_parsing_empty(t *testing.T) {
 	assertParsed(0, func(d Dockerfile) field { return len(d.Statements) }, "", t)
 }

--- a/dockerfile/tokens.go
+++ b/dockerfile/tokens.go
@@ -121,6 +121,7 @@ func (t *Tokens) NextLine() string {
 			buf.WriteRune(r)
 			if n != eof {
 				buf.WriteRune(n)
+				continue
 			}
 			break
 		} else if '\n' == r && !continued {


### PR DESCRIPTION
As discussed in #15 when reading a line and a `\` is detected, the next character will be treated as escaped. Instead of collecting both characters and continue with the next character, the missing continue leads into the break, effectively ending parsing the line prematurely.