### PR TITLE
Always use cache if available

### DIFF
--- a/command/transform/command.go
+++ b/command/transform/command.go
@@ -35,6 +35,7 @@ func (c *TransformCommand) Run(parser *dockerfile.Parser, args []string) error {
 	input := c.flags.String("in", "Dockerfile.in", "Input. Use - for standard input")
 	output := c.flags.String("out", "Dockerfile", "Output. Use - for standard output")
 	performClean := c.flags.Bool("clean", false, "Remove vendor directory after transformation")
+	noCache := c.flags.Bool("no-cache", false, "Do not use cache")
 	c.flags.Parse(args)
 
 	fmt.Fprintf(os.Stderr, "> Running transform(%q -> %q)\n", *input, *output)
@@ -51,7 +52,7 @@ func (c *TransformCommand) Run(parser *dockerfile.Parser, args []string) error {
 
 	// Transform
 	var buf bytes.Buffer
-	transformation := Transformation{Input: *input, Output: &buf}
+	transformation := Transformation{Input: *input, Output: &buf, UseCache: !*noCache}
 	if err := transformation.Run(parser); err != nil {
 		return err
 	}

--- a/command/transform/transformation.go
+++ b/command/transform/transformation.go
@@ -15,8 +15,9 @@ import (
 )
 
 type Transformation struct {
-	Input  string
-	Output io.Writer
+	Input    string
+	Output   io.Writer
+	UseCache bool
 }
 
 type Provided map[string]bool
@@ -104,7 +105,7 @@ func (t *Transformation) write(parser *dockerfile.Parser, file *dockerfile.Docke
 				return err
 			}
 
-			path, err = fetch(origin, func(transferred, total int64) {
+			path, err = fetch(origin, t.UseCache, func(transferred, total int64) {
 				percentage := float64(transferred) / float64(total)
 				finished := int(math.Max(percentage*float64(20), 20))
 				fmt.Fprintf(


### PR DESCRIPTION
Implements #22 

```dockerfile
FROM debian:jessie

USE github.com/docker-library/php/7.1
PROVIDES php:latest

USE github.com/thekid/traits/xp
```

### First run:
```sh
$ go run doget.go transform
> Running transform("Dockerfile.in" -> "Dockerfile")
> Fetching github.com/docker-library/php/7.1:master: [####################] 121.67kB
  Provides "php:latest"
> Fetching github.com/thekid/traits/xp:master: [####################] 1.30kB
Done
```

### Second (and consecutive) runs:
```sh
$ go run doget.go transform
> Running transform("Dockerfile.in" -> "Dockerfile")
> Using github.com/docker-library/php/7.1:master
  Provides "php:latest"
> Using github.com/thekid/traits/xp:master
Done
```

### Forcing DoGet not to use cache:
```sh
$ go run doget.go transform --no-cache=true
> Running transform("Dockerfile.in" -> "Dockerfile")
> Fetching github.com/docker-library/php/7.1:master: [####################] 121.67kB
  Provides "php:latest"
> Fetching github.com/thekid/traits/xp:master: [####################] 1.30kB
Done
```