### PR TITLE
[WIP] Implement build subcommand as described in #20

### DIFF
--- a/command/build/command.go
+++ b/command/build/command.go
@@ -1,0 +1,59 @@
+package build
+
+import (
+	"flag"
+	"github.com/tueftler/doget/command"
+	"github.com/tueftler/doget/command/clean"
+	"github.com/tueftler/doget/command/transform"
+	"github.com/tueftler/doget/dockerfile"
+	"os/exec"
+	"strings"
+)
+
+// BuildCommand is a thin wrapper around transform > docker build > clean
+type BuildCommand struct {
+	command.Command
+	flags *flag.FlagSet
+}
+
+// NewCommand creates new build command instance
+func NewCommand(name string) *BuildCommand {
+	return &BuildCommand{flags: flag.NewFlagSet(name, flag.ExitOnError)}
+}
+
+// Run performs action of build command
+func (b *BuildCommand) Run(parser *dockerfile.Parser, args []string) error {
+	transformArgs, dockerArgs := split(args)
+	err := transform.NewCommand("transform").Run(parser, transformArgs)
+	if nil != err {
+		return err
+	}
+
+	err = exec.Command("docker", dockerArgs...).Run()
+	if nil != err {
+		return err
+	}
+
+	err = clean.NewCommand("clean").Run(parser, []string{})
+	if nil != err {
+		return err
+	}
+
+	return nil
+}
+
+func split(args []string) ([]string, []string) {
+	transformArgs := []string{}
+	dockerArgs := []string{"build"}
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "--doget-") {
+			for _, val := range strings.Split(strings.Replace(arg, "--doget", "", 1), "=") {
+				transformArgs = append(transformArgs, val)
+			}
+		} else {
+			dockerArgs = append(dockerArgs, arg)
+		}
+	}
+
+	return transformArgs, dockerArgs
+}

--- a/command/build/command_test.go
+++ b/command/build/command_test.go
@@ -1,0 +1,22 @@
+package build
+
+import (
+	"reflect"
+	"testing"
+)
+
+func assertEqual(expect, actual interface{}, t *testing.T) {
+	if !reflect.DeepEqual(expect, actual) {
+		t.Errorf("Items not equal:\nexpected %q\nhave     %q\n", expect, actual)
+	}
+}
+
+func Test_splitArgsRecognizesTransformArgs(t *testing.T) {
+	transformArgs, _ := split([]string{"--doget-no-cache=true", "-t", "foo:bar", "--no-cache=true"})
+	assertEqual([]string{"-no-cache", "true"}, transformArgs, t)
+}
+
+func Test_splitArgsRecognizesDockerBuildArgs(t *testing.T) {
+	_, dockerArgs := split([]string{"--doget-no-cache=true", "-t", "foo:bar", "--no-cache=true"})
+	assertEqual([]string{"build", "-t", "foo:bar", "--no-cache=true"}, dockerArgs, t)
+}

--- a/command/build/command_test.go
+++ b/command/build/command_test.go
@@ -16,7 +16,17 @@ func Test_splitArgsRecognizesTransformArgs(t *testing.T) {
 	assertEqual([]string{"-no-cache", "true"}, transformArgs, t)
 }
 
+func Test_splitArgsRecognizesTransformArgWithoutValue(t *testing.T) {
+	transformArgs, _ := split([]string{"-t", "foo:bar", "--doget-clean", "--no-cache=true"})
+	assertEqual([]string{"-clean"}, transformArgs, t)
+}
+
 func Test_splitArgsRecognizesDockerBuildArgs(t *testing.T) {
-	_, dockerArgs := split([]string{"--doget-no-cache=true", "-t", "foo:bar", "--no-cache=true"})
-	assertEqual([]string{"build", "-t", "foo:bar", "--no-cache=true"}, dockerArgs, t)
+	_, dockerArgs := split([]string{"-t", "foo:bar", "--no-cache=true", "--doget-no-cache=true", "."})
+	assertEqual([]string{"build", "-t", "foo:bar", "--no-cache=true", "."}, dockerArgs, t)
+}
+
+func Test_dockerArgsContainAtLeastBuild(t *testing.T) {
+	_, dockerArgs := split([]string{})
+	assertEqual([]string{"build"}, dockerArgs, t)
 }

--- a/command/build/command_test.go
+++ b/command/build/command_test.go
@@ -58,11 +58,7 @@ func (m *mock) Init(name string) {
 
 func (m *mock) Run(parser *dockerfile.Parser, args []string) error {
 	m.executed = true
-	if nil != m.err {
-		return m.err
-	}
-
-	return nil
+	return m.err
 }
 
 func Test_dockerBuildNotExecutedWhenTransformFails(t *testing.T) {

--- a/docker/client.go
+++ b/docker/client.go
@@ -1,0 +1,27 @@
+package docker
+
+import (
+	"os/exec"
+)
+
+// Client represents the docker daemon
+type Client interface {
+	Build(args []string) error
+}
+
+// Create instantiates a new connection to the docker daemon
+func Create(target string) Client {
+	return &dockerCli{binary: target}
+}
+
+type dockerCli struct {
+	binary string
+}
+
+func (d *dockerCli) Build(args []string) error {
+	return exec.Command(d.binary, prependBuild(args)...).Run()
+}
+
+func prependBuild(args []string) []string {
+	return append([]string{"build"}, args...)
+}

--- a/doget.go
+++ b/doget.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/tueftler/doget/command"
+	"github.com/tueftler/doget/command/build"
 	"github.com/tueftler/doget/command/clean"
 	"github.com/tueftler/doget/command/dump"
 	"github.com/tueftler/doget/command/transform"
@@ -16,6 +17,7 @@ import (
 
 var (
 	commands = map[string]command.Command{
+		"build":     build.NewCommand("build"),
 		"dump":      dump.NewCommand("dump"),
 		"transform": transform.NewCommand("transform"),
 		"clean":     clean.NewCommand("clean"),
@@ -32,7 +34,7 @@ func configuration(file string) (*config.Configuration, error) {
 
 func main() {
 	var (
-		cmdName    = flag.String("#1", "", "Command, one of [clean, dump, transform]")
+		cmdName    = flag.String("#1", "", "Command, one of [build, clean, dump, transform]")
 		configFile = flag.String("config", "", "Configuration file to use")
 	)
 	flag.Parse()

--- a/doget.go
+++ b/doget.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tueftler/doget/command/dump"
 	"github.com/tueftler/doget/command/transform"
 	"github.com/tueftler/doget/config"
+	"github.com/tueftler/doget/docker"
 	"github.com/tueftler/doget/dockerfile"
 	"github.com/tueftler/doget/provides"
 	"github.com/tueftler/doget/use"
@@ -16,13 +17,20 @@ import (
 )
 
 var (
-	commands = map[string]command.Command{
-		"build":     build.NewCommand("build"),
-		"dump":      dump.NewCommand("dump"),
-		"transform": transform.NewCommand("transform"),
-		"clean":     clean.NewCommand("clean"),
-	}
+	commands = make(map[string]command.Command)
 )
+
+func init() {
+	commands["dump"] = dump.NewCommand("dump")
+	commands["transform"] = transform.NewCommand("transform")
+	commands["clean"] = clean.NewCommand("clean")
+	commands["build"] = build.NewCommand(
+		"build",
+		commands["transform"],
+		commands["clean"],
+		docker.Create("docker"),
+	)
+}
 
 func configuration(file string) (*config.Configuration, error) {
 	if file == "" {


### PR DESCRIPTION
This implements the `doget build` subcommand as outlined in #20.

Currently the docker client is injected. However, it might be better to inject a function which creates the docker client, so it becomes possible to define the docker binary (or docker http daemon) as
command line argument to the build command.

At the moment this introduces a separate docker package. It should be discussed on whether to keep this, or if this should be part of the command/build package itself.