### PR TITLE
store complete file header in zip, fixes #28

### DIFF
--- a/command/transform/zip.go
+++ b/command/transform/zip.go
@@ -29,7 +29,14 @@ func mkzip(src, dest string) error {
 			}
 			defer o.Close()
 
-			z, err := w.Create(filepath.ToSlash(path))
+			h, err := zip.FileInfoHeader(info)
+			if err != nil {
+				return err
+			}
+
+			// modify to provide full path name
+			h.Name = filepath.ToSlash(path)
+			z, err := w.CreateHeader(h)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
See #28 for reasoning.